### PR TITLE
Fix wrong type declaration in WITH-STREAM-SOURCE

### DIFF
--- a/src/source.lisp
+++ b/src/source.lisp
@@ -265,7 +265,7 @@
                (,p (pos ,source))
                ,@(when end `((,e1 (end ,source))))
                (,e ,(or end `(end ,source))))
-           (declare (type file-stream ,v)
+           (declare (type stream ,v)
                     (type fixnum ,p))
            (labels ((ub8 ()
                       (when ,e (assert (< ,p ,e)))


### PR DESCRIPTION
This caused it to fail on SBCL when used with non-file streams